### PR TITLE
fix: cap temporal extraction loop to prevent DoS

### DIFF
--- a/engine/src/services/search/query-parser.ts
+++ b/engine/src/services/search/query-parser.ts
@@ -93,12 +93,18 @@ export function extractTemporalContext(query: string): string[] {
     const now = new Date();
     const currentYear = now.getFullYear();
     const tags: Set<string> = new Set();
+    const MAX_TEMPORAL_AMOUNT = 100;
 
     // Regex for "last X months/years"
     const match = query.match(/last\s+(\d+)\s+(months?|years?|days?)/i);
     if (match) {
-        const amount = parseInt(match[1]);
+        let amount = parseInt(match[1]);
         const unit = match[2].toLowerCase();
+
+        // Security: Cap the amount to prevent loop exhaustion DoS
+        if (amount > MAX_TEMPORAL_AMOUNT) {
+            amount = MAX_TEMPORAL_AMOUNT;
+        }
 
         tags.add(currentYear.toString()); // Always include current year
 

--- a/engine/tests/unit/test_temporal_limit.ts
+++ b/engine/tests/unit/test_temporal_limit.ts
@@ -1,0 +1,55 @@
+
+import { extractTemporalContext } from '../../src/services/search/query-parser.js';
+
+async function testTemporalLimit() {
+    console.log('--- Testing Temporal Context Limit ---');
+
+    const maxLimit = 100; // The limit we plan to implement (plus current year, plus small buffer)
+
+    // Case 1: Huge number of years
+    {
+        const hugeAmount = 10000;
+        const query = `last ${hugeAmount} years`;
+
+        console.log(`Testing query: "${query}"`);
+        const start = Date.now();
+        const tags = extractTemporalContext(query);
+        const duration = Date.now() - start;
+
+        console.log(`Generated ${tags.length} tags in ${duration}ms`);
+
+        // We expect tags count to be capped around 100 + 1 (current year).
+        // Let's say < 150 to be safe.
+        if (tags.length > 150) {
+            console.error(`❌ FAIL: Generated too many tags (${tags.length}). Expected around ${maxLimit}.`);
+            process.exit(1);
+        } else {
+            console.log(`✅ PASS: Tag count is within safe limits.`);
+        }
+    }
+
+    // Case 2: Huge number of months
+    {
+        const hugeAmount = 100000; // 100k months is ~8000 years
+        const query = `last ${hugeAmount} months`;
+
+        console.log(`Testing query: "${query}"`);
+        const start = Date.now();
+        const tags = extractTemporalContext(query);
+        const duration = Date.now() - start;
+
+        console.log(`Generated ${tags.length} tags in ${duration}ms`);
+
+        if (tags.length > 150) {
+             console.error(`❌ FAIL: Generated too many tags (${tags.length}). Expected around ${maxLimit}.`);
+             process.exit(1);
+        } else {
+            console.log(`✅ PASS: Tag count is within safe limits.`);
+        }
+    }
+}
+
+testTemporalLimit().catch(e => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
Fixed a potential Denial of Service vulnerability in `query-parser.ts` where an unbounded user-supplied `amount` could cause excessive loop iterations. Introduced `MAX_TEMPORAL_AMOUNT` constant (100) to cap the number of iterations.

---
*PR created automatically by Jules for task [10043821001154182026](https://jules.google.com/task/10043821001154182026) started by @RSBalchII*