### PR TITLE
Parse source metadata JSON in C++ core

### DIFF
--- a/cpp/include/types.h
+++ b/cpp/include/types.h
@@ -7,6 +7,7 @@
 #define ANCHOR_CORE_TYPES_H
 
 #include "common.h"
+#include <nlohmann/json.hpp>
 
 namespace anchor {
 
@@ -69,7 +70,7 @@ struct Source {
     std::optional<std::string> bucket;
     Timestamp created_at;
     Timestamp updated_at;
-    std::optional<std::string> metadata;  // JSON as string for now
+    std::optional<nlohmann::json> metadata;
 };
 
 /**

--- a/cpp/src/database.cpp
+++ b/cpp/src/database.cpp
@@ -332,8 +332,9 @@ void Database::upsertSource(const Source& source) {
 
     std::string metadata_str = "NULL";
     if (source.metadata.has_value()) {
+        // Serialize JSON to string
+        std::string escaped = source.metadata.value().dump();
         // Escape single quotes in metadata string
-        std::string escaped = source.metadata.value();
         size_t pos = 0;
         while ((pos = escaped.find("'", pos)) != std::string::npos) {
             escaped.replace(pos, 1, "''");
@@ -384,7 +385,11 @@ Source Database::getSource(const SourceId& id) const {
         
         if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
             std::string metadata_json = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5));
-            // TODO: Parse JSON metadata
+            try {
+                source.metadata = nlohmann::json::parse(metadata_json);
+            } catch (const nlohmann::json::parse_error&) {
+                // Ignore parse error
+            }
         }
     } else {
         sqlite3_finalize(stmt);
@@ -418,6 +423,15 @@ std::vector<Source> Database::listSources() const {
         source.created_at = sqlite3_column_double(stmt, 3);
         source.updated_at = sqlite3_column_double(stmt, 4);
         
+        if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) {
+            std::string metadata_json = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5));
+            try {
+                source.metadata = nlohmann::json::parse(metadata_json);
+            } catch (const nlohmann::json::parse_error&) {
+                // Ignore parse error
+            }
+        }
+
         sources.push_back(source);
     }
     


### PR DESCRIPTION
- Modified `cpp/include/types.h` to change `Source::metadata` type to `std::optional<nlohmann::json>`.
- Modified `cpp/src/database.cpp` to:
  - Serialize `metadata` to string in `upsertSource`.
  - Parse `metadata` string to JSON in `getSource` and `listSources`.
  - Handle potential JSON parsing errors.
- Verified changes with a custom C++ test program.

---
*PR created automatically by Jules for task [7506433461255067352](https://jules.google.com/task/7506433461255067352) started by @RSBalchII*