### PR TITLE
🔒 Fix Arbitrary File Write via Path Traversal in /v1/research/upload-raw

### DIFF
--- a/engine/src/routes/api.ts
+++ b/engine/src/routes/api.ts
@@ -759,7 +759,10 @@ export function setupRoutes(app: Application) {
       const targetDir = path.join(ENGINE_PLUGINS, 'articles');
       if (!fs.existsSync(targetDir)) fs.mkdirSync(targetDir, { recursive: true });
 
-      const filePath = path.join(targetDir, filename);
+      // Fix for Arbitrary File Write via Path Traversal
+      // Ensure filename does not contain directory traversal characters
+      const safeFilename = path.basename(filename);
+      const filePath = path.join(targetDir, safeFilename);
       await fs.promises.writeFile(filePath, content, 'utf8');
 
       console.log(`[Research] Manual upload saved: ${filePath}`);


### PR DESCRIPTION
This PR addresses a security vulnerability in the `/v1/research/upload-raw` endpoint where unsanitized filenames could be used to write files to arbitrary locations on the filesystem (Arbitrary File Write).

**Changes:**
- Modified `engine/src/routes/api.ts` to sanitize the `filename` provided in the request body using `path.basename()`.

**Verification:**
- Verified the fix logic with a standalone script (`verify_fix_logic.ts`) confirming that `path.basename` strips directory components (e.g., `../../etc/passwd` becomes `passwd`).
- Confirmed the vulnerability with a reproduction script (`reproduce_exploit_standalone.ts`) that successfully wrote a file outside the target directory before the fix.
- Confirmed the fix with a simulated fixed script (`reproduce_exploit_standalone_fixed.ts`) that successfully wrote the file to the correct directory after sanitization.


---
*PR created automatically by Jules for task [10334371066266108405](https://jules.google.com/task/10334371066266108405) started by @RSBalchII*