### PR TITLE
🔒 Fix SSRF vulnerability in research scraper

### DIFF
--- a/engine/src/services/research/researcher.ts
+++ b/engine/src/services/research/researcher.ts
@@ -5,7 +5,9 @@ import TurndownService from 'turndown';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import * as net from 'net';
 import { ENGINE_PLUGINS } from '../../config/paths.js';
+import { safeLookup, isPrivateIP } from '../../utils/safe-dns.js';
 
 const PLUGINS_DIR = ENGINE_PLUGINS;
 
@@ -38,7 +40,19 @@ export async function fetchAndProcess(url: string, category: 'article' | 'paper'
     try {
         console.log(`[Research] Fetching: ${url}`);
 
-        const response = await gotScraping(url, { timeout: { request: 10000 } });
+        const urlObj = new URL(url);
+        if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+            throw new Error(`Invalid protocol: ${urlObj.protocol}. Only http and https are allowed.`);
+        }
+
+        if (net.isIP(urlObj.hostname) !== 0 && isPrivateIP(urlObj.hostname)) {
+            throw new Error(`Invalid IP address: ${urlObj.hostname}. Private IPs are not allowed.`);
+        }
+
+        const response = await gotScraping(url, {
+            timeout: { request: 10000 },
+            dnsLookup: safeLookup
+        });
 
         const html = response.body;
         const $ = cheerio.load(html);

--- a/engine/src/utils/safe-dns.ts
+++ b/engine/src/utils/safe-dns.ts
@@ -1,0 +1,113 @@
+import dns from 'node:dns';
+
+/**
+ * Checks if an IP address is private or reserved.
+ * Handles IPv4 and IPv6.
+ *
+ * @param ip - The IP address string
+ * @returns true if the IP is private or reserved, false otherwise.
+ */
+export function isPrivateIP(ip: string): boolean {
+    // IPv4
+    if (ip.includes('.')) {
+        // If it also contains ':', it might be IPv6 mapped, but usually IPv4 doesn't contain ':'.
+        // However, if it's strictly IPv4, it shouldn't have ':'.
+        // If it's IPv6 with embedded IPv4, it falls into the else if below unless it's just an IPv4 string.
+
+        const parts = ip.split('.').map(Number);
+        if (parts.length !== 4) return false;
+
+        // 127.0.0.0/8 - Loopback
+        if (parts[0] === 127) return true;
+        // 10.0.0.0/8 - Private Network
+        if (parts[0] === 10) return true;
+        // 192.168.0.0/16 - Private Network
+        if (parts[0] === 192 && parts[1] === 168) return true;
+        // 172.16.0.0/12 - Private Network (172.16.x.x - 172.31.x.x)
+        if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
+        // 169.254.0.0/16 - Link-local
+        if (parts[0] === 169 && parts[1] === 254) return true;
+        // 0.0.0.0/8 - Current network (only valid as source address)
+        if (parts[0] === 0) return true;
+
+        return false;
+    }
+    // IPv6
+    else if (ip.includes(':')) {
+        const lowerIp = ip.toLowerCase();
+
+        // ::1/128 - Loopback
+        if (lowerIp === '::1' || lowerIp === '0:0:0:0:0:0:0:1') return true;
+
+        // ::/128 - Unspecified
+        if (lowerIp === '::' || lowerIp === '0:0:0:0:0:0:0:0') return true;
+
+        // fc00::/7 - Unique Local Address
+        // Check if starts with fc or fd (case insensitive)
+        const firstBlock = lowerIp.split(':')[0];
+        if (firstBlock.length > 0) {
+            const val = parseInt(firstBlock, 16);
+            // fc00::/7 covers fc00 to fdff
+            if (!isNaN(val) && ((val >> 8) & 0xfe) === 0xfc) return true;
+        }
+
+        // fe80::/10 - Link-local
+        if (lowerIp.startsWith('fe8') || lowerIp.startsWith('fe9') || lowerIp.startsWith('fea') || lowerIp.startsWith('feb')) return true;
+
+        // IPv4-mapped IPv6 ::ffff:127.0.0.1
+        if (lowerIp.startsWith('::ffff:')) {
+            const ipv4 = lowerIp.substring(7);
+             if (ipv4.includes('.')) {
+                 return isPrivateIP(ipv4);
+             }
+        }
+
+        // Also check for 0:0:0:0:0:ffff:127.0.0.1 style if not normalized
+        if (lowerIp.includes('.')) {
+             // It's likely an embedded IPv4
+             const parts = lowerIp.split(':');
+             const lastPart = parts[parts.length - 1];
+             if (lastPart.includes('.')) {
+                 return isPrivateIP(lastPart);
+             }
+        }
+
+        return false;
+    }
+    return false;
+}
+
+/**
+ * Custom DNS lookup function for `got` that prevents resolving to private IP addresses.
+ */
+export function safeLookup(
+    hostname: string,
+    options: dns.LookupOptions,
+    callback: (err: NodeJS.ErrnoException | null, address: string | dns.LookupAddress[], family?: number) => void
+): void {
+    dns.lookup(hostname, options, (err, address, family) => {
+        if (err) {
+            callback(err, address as any, family);
+            return;
+        }
+
+        const addressesToCheck: string[] = [];
+
+        if (Array.isArray(address)) {
+            address.forEach(a => addressesToCheck.push(a.address));
+        } else if (typeof address === 'string') {
+            addressesToCheck.push(address);
+        }
+
+        for (const addr of addressesToCheck) {
+            if (isPrivateIP(addr)) {
+                const error = new Error(`DNS lookup for ${hostname} resolved to a private IP: ${addr}`);
+                (error as any).code = 'ERR_SSRF_PROTECTION';
+                callback(error as NodeJS.ErrnoException, address as any, family);
+                return;
+            }
+        }
+
+        callback(null, address as any, family);
+    });
+}


### PR DESCRIPTION
This PR fixes a Server-Side Request Forgery (SSRF) vulnerability in the `fetchAndProcess` function of the research service.

The vulnerability allowed an attacker to supply a URL that resolves to an internal IP address (e.g., localhost, 127.0.0.1, AWS metadata service), potentially exposing sensitive internal services.

Changes:
1.  Created `engine/src/utils/safe-dns.ts`:
    *   Exports `isPrivateIP(ip)`: robustly checks if an IP is private or reserved.
    *   Exports `safeLookup`: A custom DNS lookup function compatible with `got` that resolves hostnames and validates the resulting IPs using `isPrivateIP`.
2.  Modified `engine/src/services/research/researcher.ts`:
    *   Added protocol validation (only `http:` and `https:` are allowed).
    *   Added direct IP validation: if the hostname is an IP, it is checked against `isPrivateIP` *before* the request is made (since `got` bypasses DNS lookup for IP literals).
    *   Configured `gotScraping` to use `safeLookup` for DNS resolution, protecting against DNS rebinding attacks.

Testing:
*   Verified with a reproduction script that `localhost`, `127.0.0.1`, `0.0.0.0`, `169.254.169.254`, and `ftp://` URLs are blocked.
*   Verified that valid external URLs (e.g., `example.com`) are still accessible.
*   Verified IPv6 private address blocking logic.

---
*PR created automatically by Jules for task [11760986695719166009](https://jules.google.com/task/11760986695719166009) started by @RSBalchII*