### PR TITLE
🔒 Security: Reduce excessive JSON request body limit

### DIFF
--- a/engine/src/index.ts
+++ b/engine/src/index.ts
@@ -19,8 +19,12 @@ const __dirname = path.dirname(__filename);
 const app: express.Application = express();
 const PORT = config.PORT;
 
+// Security Fix: Limit JSON body size to prevent DoS via large payloads
+// Use configured file size limit + 50% buffer for JSON overhead (base64/escaping)
+const jsonLimit = Math.ceil((config.LIMITS?.MAX_FILE_SIZE_BYTES || 10 * 1024 * 1024) * 1.5);
+
 app.use(cors());
-app.use(express.json({ limit: "50mb" }));
+app.use(express.json({ limit: jsonLimit }));
 app.use(express.urlencoded({ extended: true }));
 
 // HTTP Request Logging Middleware

--- a/engine/src/services/search/search.ts
+++ b/engine/src/services/search/search.ts
@@ -114,18 +114,19 @@ export async function findAnchors(
     }
 
     let anchors: SearchResult[] = [];
+    let atomResults: SearchResult[] = [];
 
     // A. Atom Search (Radial Inflation) - Use C++ results if available
     if (cppResults.length > 0) {
       // Transform C++ results to SearchResult format
-      anchors = cppResults.map((r: any) => ({
+      atomResults = cppResults.map((r: any) => ({
         id: String(r.id),
         content: r.content,
         source: r.source_id,
         timestamp: r.timestamp,
         buckets: r.buckets || [],
         tags: r.tags || [],
-        epochs: [],
+        epochs: '',
         provenance: 'internal',
         score: r.simhash ? 1.0 : 0.5,
         sequence: 0,
@@ -133,15 +134,15 @@ export async function findAnchors(
         start_byte: r.start_byte,
         end_byte: r.end_byte,
         type: 'atom',
-        numeric_value: null,
-        numeric_unit: null,
+        numeric_value: undefined,
+        numeric_unit: undefined,
         compound_id: r.compound_id
       }));
+      anchors = atomResults;
       console.log(`[Search] Using C++ backend results: ${anchors.length} atoms`);
     } else {
       // Fallback to PGlite
       const terms = sanitizedQuery.split(/\s+/).filter(t => t.length > 0);
-      const atomResults: SearchResult[] = [];
 
       if (terms.length > 0) {
         try {

--- a/engine/src/utils/structured-logger.ts
+++ b/engine/src/utils/structured-logger.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from 'url';
 // Get absolute path to project root (anchor-os directory)
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const PROJECT_ROOT = path.resolve(__dirname, '../../../../..');
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 
 // Define log levels with numerical values
 const logLevels = {


### PR DESCRIPTION
This PR addresses a security vulnerability where the Express server allowed excessive JSON payload sizes (50MB), potentially leading to DoS via memory exhaustion. The limit is now dynamically set based on the configured `MAX_FILE_SIZE_BYTES` (default 10MB) with a 50% buffer for JSON overhead.

Additionally, this PR includes bug fixes required to run the server for verification:
- Fixed a path traversal issue in `structured-logger.ts` that caused the server to crash on startup by trying to create `/logs`.
- Fixed TypeScript errors in `search.ts` related to variable scoping and type mismatches.

---
*PR created automatically by Jules for task [7756138242653951270](https://jules.google.com/task/7756138242653951270) started by @RSBalchII*