### PR TITLE
Implement geometric overlap calculation for deduplication

### DIFF
--- a/cpp/include/types.h
+++ b/cpp/include/types.h
@@ -97,6 +97,11 @@ struct Candidate {
     
     // For deduplication tracking
     std::vector<std::string> content_fingerprints;
+
+    // For geometric overlap
+    SourceId source_id;
+    std::optional<size_t> start_byte;
+    std::optional<size_t> end_byte;
 };
 
 /**

--- a/cpp/src/deduplicator.cpp
+++ b/cpp/src/deduplicator.cpp
@@ -83,13 +83,43 @@ double Deduplicator::computeGeometricOverlap(
     // For atoms with byte coordinates
     // Overlap = intersection / union
     
-    // Note: In real implementation, would use start_byte and end_byte
-    // For now, return 0 (no overlap detected)
+    // Check if source matches
+    if (a.source_id != b.source_id) {
+        return 0.0;
+    }
+
+    // Check if byte coordinates are available
+    if (!a.start_byte.has_value() || !a.end_byte.has_value() ||
+        !b.start_byte.has_value() || !b.end_byte.has_value()) {
+        return 0.0;
+    }
+
+    size_t start_a = a.start_byte.value();
+    size_t end_a = a.end_byte.value();
+    size_t start_b = b.start_byte.value();
+    size_t end_b = b.end_byte.value();
+
+    // Calculate intersection
+    size_t intersect_start = std::max(start_a, start_b);
+    size_t intersect_end = std::min(end_a, end_b);
+
+    if (intersect_start >= intersect_end) {
+        return 0.0; // No intersection
+    }
+
+    double intersection_len = static_cast<double>(intersect_end - intersect_start);
+
+    // Calculate union
+    size_t union_start = std::min(start_a, start_b);
+    size_t union_end = std::max(end_a, end_b);
     
-    // Placeholder implementation
-    // TODO: Load atom coordinates and compute actual overlap
-    
-    return 0.0;
+    double union_len = static_cast<double>(union_end - union_start);
+
+    if (union_len == 0.0) {
+        return 0.0;
+    }
+
+    return intersection_len / union_len;
 }
 
 bool Deduplicator::checkMD5Fingerprint(

--- a/cpp/src/physics_walker.cpp
+++ b/cpp/src/physics_walker.cpp
@@ -164,6 +164,9 @@ void PhysicsWalker::traverseGraph(Database& db,
                     auto atom = db.getAtom(edge.to);
                     candidate.timestamp = atom.timestamp;
                     candidate.simhash = atom.simhash;
+                    candidate.source_id = atom.source_id;
+                    candidate.start_byte = atom.start_byte;
+                    candidate.end_byte = atom.end_byte;
                 } catch (...) {
                     continue;
                 }


### PR DESCRIPTION
Implemented the geometric overlap calculation for deduplication in the C++ core. This allows the system to identify and filter out candidates that have significant byte-range overlap within the same source document.

The implementation:
1.  Extends `Candidate` struct to carry byte coordinates and source ID.
2.  Populates these fields during graph traversal in `PhysicsWalker`.
3.  Calculates IoU in `Deduplicator` and returns 0.0 if sources differ or overlap is insufficient.

This replaces the placeholder implementation in `deduplicator.cpp`.

---
*PR created automatically by Jules for task [10952657940063171188](https://jules.google.com/task/10952657940063171188) started by @RSBalchII*