### PR TITLE
Implement parameter binding for atom metadata in C++ backend

### DIFF
--- a/cpp/src/database.cpp
+++ b/cpp/src/database.cpp
@@ -481,7 +481,29 @@ AtomId Database::insertAtom(const Atom& atom) {
     std::string simhash_hex = "0x" + std::to_string(atom.simhash);
     sqlite3_bind_text(stmt, 6, simhash_hex.c_str(), -1, SQLITE_STATIC);
     
-    // TODO: Bind metadata, compound_id, start_byte, end_byte
+    if (atom.metadata.has_value()) {
+        sqlite3_bind_text(stmt, 7, atom.metadata->c_str(), -1, SQLITE_STATIC);
+    } else {
+        sqlite3_bind_null(stmt, 7);
+    }
+
+    if (atom.compound_id.has_value()) {
+        sqlite3_bind_text(stmt, 8, atom.compound_id->c_str(), -1, SQLITE_STATIC);
+    } else {
+        sqlite3_bind_null(stmt, 8);
+    }
+
+    if (atom.start_byte.has_value()) {
+        sqlite3_bind_int(stmt, 9, static_cast<int>(*atom.start_byte));
+    } else {
+        sqlite3_bind_null(stmt, 9);
+    }
+
+    if (atom.end_byte.has_value()) {
+        sqlite3_bind_int(stmt, 10, static_cast<int>(*atom.end_byte));
+    } else {
+        sqlite3_bind_null(stmt, 10);
+    }
     
     if (sqlite3_step(stmt) != SQLITE_DONE) {
         sqlite3_finalize(stmt);
@@ -534,7 +556,21 @@ Atom Database::getAtom(AtomId id) const {
         std::string simhash_str = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 6));
         atom.simhash = std::stoull(simhash_str, nullptr, 16);
         
-        // TODO: Parse metadata, compound_id, start_byte, end_byte
+        if (sqlite3_column_type(stmt, 7) != SQLITE_NULL) {
+            atom.metadata = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 7));
+        }
+
+        if (sqlite3_column_type(stmt, 8) != SQLITE_NULL) {
+            atom.compound_id = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 8));
+        }
+
+        if (sqlite3_column_type(stmt, 9) != SQLITE_NULL) {
+            atom.start_byte = sqlite3_column_int(stmt, 9);
+        }
+
+        if (sqlite3_column_type(stmt, 10) != SQLITE_NULL) {
+            atom.end_byte = sqlite3_column_int(stmt, 10);
+        }
     } else {
         sqlite3_finalize(stmt);
         throw DatabaseError("Atom not found: " + std::to_string(id));

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(test_atom_binding test_atom_binding.cpp)
+
+target_link_libraries(test_atom_binding
+    PRIVATE
+    anchor_core
+)
+
+target_include_directories(test_atom_binding
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+add_test(NAME test_atom_binding COMMAND test_atom_binding)

--- a/cpp/tests/test_atom_binding.cpp
+++ b/cpp/tests/test_atom_binding.cpp
@@ -1,0 +1,89 @@
+#include <iostream>
+#include <cassert>
+#include <vector>
+#include <optional>
+#include "database.h"
+#include "types.h"
+
+using namespace anchor;
+
+void test_atom_binding() {
+    std::cout << "Testing atom binding..." << std::endl;
+
+    // 1. Initialize Database
+    Database db = Database::inMemory();
+
+    // 2. Create a Source (foreign key requirement)
+    Source source;
+    source.id = "src1";
+    source.path = "/tmp/test.txt";
+    source.created_at = 1000.0;
+    source.updated_at = 1000.0;
+    db.upsertSource(source);
+
+    // 3. Create Atom with all fields
+    Atom atom1;
+    atom1.source_id = "src1";
+    atom1.content = "content1";
+    atom1.char_start = 0;
+    atom1.char_end = 8;
+    atom1.timestamp = 1001.0;
+    atom1.simhash = 12345;
+    atom1.metadata = "meta1";
+    atom1.compound_id = "cmp1";
+    atom1.start_byte = 10;
+    atom1.end_byte = 20;
+
+    // 4. Insert Atom
+    AtomId id1 = db.insertAtom(atom1);
+
+    // 5. Retrieve Atom
+    Atom retrieved1 = db.getAtom(id1);
+
+    // 6. Verify fields
+    assert(retrieved1.metadata.has_value());
+    assert(*retrieved1.metadata == "meta1");
+    assert(retrieved1.compound_id.has_value());
+    assert(*retrieved1.compound_id == "cmp1");
+    assert(retrieved1.start_byte.has_value());
+    assert(*retrieved1.start_byte == 10);
+    assert(retrieved1.end_byte.has_value());
+    assert(*retrieved1.end_byte == 20);
+
+    std::cout << "  Passed: All fields populated." << std::endl;
+
+    // 7. Create Atom with optional fields empty
+    Atom atom2;
+    atom2.source_id = "src1";
+    atom2.content = "content2";
+    atom2.char_start = 10;
+    atom2.char_end = 18;
+    atom2.timestamp = 1002.0;
+    atom2.simhash = 67890;
+    // metadata, compound_id, start_byte, end_byte are empty by default
+
+    // 8. Insert Atom
+    AtomId id2 = db.insertAtom(atom2);
+
+    // 9. Retrieve Atom
+    Atom retrieved2 = db.getAtom(id2);
+
+    // 10. Verify fields
+    assert(!retrieved2.metadata.has_value());
+    assert(!retrieved2.compound_id.has_value());
+    assert(!retrieved2.start_byte.has_value());
+    assert(!retrieved2.end_byte.has_value());
+
+    std::cout << "  Passed: Optional fields empty." << std::endl;
+}
+
+int main() {
+    try {
+        test_atom_binding();
+        std::cout << "All tests passed!" << std::endl;
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
Implemented the binding of `metadata`, `compound_id`, `start_byte`, and `end_byte` in `Database::insertAtom` and their retrieval in `Database::getAtom`. Added a C++ unit test `cpp/tests/test_atom_binding.cpp` to verify the functionality.

---
*PR created automatically by Jules for task [2725638584579151336](https://jules.google.com/task/2725638584579151336) started by @RSBalchII*