### PR TITLE
🧹 Remove unused commented-out import in db.ts

### DIFF
--- a/engine/src/core/db.ts
+++ b/engine/src/core/db.ts
@@ -11,7 +11,6 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { PGlite } from "@electric-sql/pglite";
-// import { vector } from "@electric-sql/pglite/extensions/vector"; // Commenting out since it may not be available
 
 const __filename = fileURLToPath(import.meta.url);
 


### PR DESCRIPTION
🎯 **What:** Removed the commented-out line `// import { vector } ...` in `engine/src/core/db.ts`.
💡 **Why:** The import was unused and commented out, adding unnecessary noise to the code.
✅ **Verification:** 
- Created a test script `engine/test_db_import.ts` to verify `db.ts` can be imported without errors.
- Ran `tsc` to ensure no compilation errors were introduced in `src/core/db.ts`.
✨ **Result:** Cleaner code in `engine/src/core/db.ts`.

---
*PR created automatically by Jules for task [5778600527944200754](https://jules.google.com/task/5778600527944200754) started by @RSBalchII*