### PR TITLE
feat: Implement engram result hydration in search service

### DIFF
--- a/engine/src/services/search/search.ts
+++ b/engine/src/services/search/search.ts
@@ -66,6 +66,57 @@ export async function lookupByEngram(key: string): Promise<string[]> {
   return [];
 }
 
+/**
+ * Hydrate atom IDs into full SearchResult objects
+ */
+export async function hydrateEngramResults(ids: string[]): Promise<SearchResult[]> {
+  if (!ids || ids.length === 0) return [];
+
+  // Remove duplicates
+  const uniqueIds = Array.from(new Set(ids));
+
+  try {
+    const query = `
+      SELECT id, content, source_path as source, timestamp, buckets, tags,
+             epochs, provenance, 1.0 as score,
+             sequence, molecular_signature, compound_id, start_byte, end_byte,
+             type, numeric_value, numeric_unit
+      FROM atoms
+      WHERE id = ANY($1)
+    `;
+    const result = await db.run(query, [uniqueIds]);
+
+    if (!result.rows) return [];
+
+    const atoms = result.rows.map((row: any) => ({
+        id: row.id,
+        content: row.content,
+        source: row.source,
+        timestamp: row.timestamp,
+        buckets: row.buckets || [],
+        tags: row.tags || [],
+        epochs: Array.isArray(row.epochs) ? row.epochs.join(',') : (row.epochs || ''),
+        provenance: row.provenance,
+        score: row.score,
+        sequence: row.sequence,
+        molecular_signature: row.molecular_signature,
+        compound_id: row.compound_id,
+        start_byte: row.start_byte,
+        end_byte: row.end_byte,
+        type: row.type,
+        numeric_value: row.numeric_value,
+        numeric_unit: row.numeric_unit
+    }));
+
+    await hydrateFromMirror(atoms);
+
+    return atoms;
+  } catch (e) {
+    console.error('[Search] Failed to hydrate engram results:', e);
+    return [];
+  }
+}
+
 import { PhysicsTagWalker } from './physics-tag-walker.js';
 import { assembleAndSerialize, assembleContextPackage } from './graph-context-serializer.js';
 import { UserContext } from '../../types/context.js';
@@ -115,7 +166,6 @@ export async function findAnchors(
     }
 
     let anchors: SearchResult[] = [];
-    let atomResults: SearchResult[] = [];
 
     // A. Atom Search (Radial Inflation) - Use C++ results if available
     if (cppResults.length > 0) {
@@ -535,15 +585,13 @@ export async function executeSearch(
 
   // 2. Find Anchors (Planets)
   // Combine Engram Lookup + FTS + Molecule Search
-  const engramResults = await lookupByEngram(cleanQuery); // TODO: Hydrate these results
+  const engramIds = await lookupByEngram(cleanQuery);
+  const engramResults = await hydrateEngramResults(engramIds);
+  console.log(`[Search] Hydrated ${engramResults.length} engram results`);
+
   const primaryAnchors = await findAnchors(cleanQuery, Array.from(realBuckets), explicitTags, maxChars, provenance, filters);
 
-  // Clean up engram results if they are just IDs (lookupByEngram returns IDs? No, currently logic is missing hydration in my quick look, assuming compatible or empty)
-  // Actually lookupByEngram returns string[] of IDs. We need to fetch them.
-  // For now, let's rely on primaryAnchors.
-  // If we had time, we'd hydrate engrams.
-
-  const allAnchors = [...primaryAnchors];
+  const allAnchors = [...engramResults, ...primaryAnchors];
 
   // Deduplicate
   const seenIds = new Set<string>();

--- a/engine/tests/unit/test_engram_hydration.ts
+++ b/engine/tests/unit/test_engram_hydration.ts
@@ -1,0 +1,73 @@
+import { db } from '../../src/core/db.js';
+import { hydrateEngramResults } from '../../src/services/search/search.js';
+import { SearchResult } from '../../src/services/search/search-utils.js';
+
+async function testEngramHydration() {
+  console.log('--- Testing Engram Hydration ---');
+
+  // Initialize DB
+  await db.init();
+
+  const testId = 'test-atom-id';
+  const testContent = 'This is a test atom for engram hydration.';
+  const testSource = 'test-source.md';
+
+  // Insert a test atom
+  // Note: epochs is TEXT[] in DB schema
+  const insertQuery = `
+    INSERT INTO atoms (id, content, source_path, timestamp, provenance, buckets, tags, epochs)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+  `;
+
+  await db.run(insertQuery, [
+    testId,
+    testContent,
+    testSource,
+    Date.now(),
+    'internal',
+    ['test-bucket'],
+    ['test-tag'],
+    ['epoch1']
+  ]);
+
+  console.log('Inserted test atom.');
+
+  // Hydrate the atom
+  const results = await hydrateEngramResults([testId]);
+
+  console.log(`Hydrated ${results.length} results.`);
+
+  if (results.length !== 1) {
+    console.error(`❌ FAIL: Expected 1 result, got ${results.length}`);
+    process.exit(1);
+  }
+
+  const atom = results[0];
+  if (atom.id !== testId) {
+    console.error(`❌ FAIL: ID mismatch. Expected ${testId}, got ${atom.id}`);
+    process.exit(1);
+  }
+  if (atom.content !== testContent) {
+    console.error(`❌ FAIL: Content mismatch. Expected "${testContent}", got "${atom.content}"`);
+    process.exit(1);
+  }
+  if (!atom.buckets.includes('test-bucket')) {
+    console.error(`❌ FAIL: Bucket mismatch.`);
+    process.exit(1);
+  }
+  if (!atom.tags.includes('test-tag')) {
+      console.error(`❌ FAIL: Tag mismatch.`);
+      process.exit(1);
+  }
+  if (!atom.epochs.includes('epoch1')) {
+      console.error(`❌ FAIL: Epoch mismatch.`);
+      process.exit(1);
+  }
+
+  console.log('✅ PASS: Engram hydration verified successfully.');
+}
+
+testEngramHydration().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
This PR implements the missing hydration logic for engram results in the search service. Previously, `lookupByEngram` returned IDs but they were not converted into full `SearchResult` objects. This change adds `hydrateEngramResults` to fetch the necessary data from the `atoms` table, including handling the `epochs` array correctly. It also fixes a duplicate variable declaration bug in `search.ts` and includes a unit test verification.

---
*PR created automatically by Jules for task [15500400549731454438](https://jules.google.com/task/15500400549731454438) started by @RSBalchII*