### PR TITLE
Hydrate engram search results

### DIFF
--- a/engine/src/services/search/search.ts
+++ b/engine/src/services/search/search.ts
@@ -66,6 +66,41 @@ export async function lookupByEngram(key: string): Promise<string[]> {
   return [];
 }
 
+/**
+ * Hydrate engram IDs into full SearchResult objects
+ */
+export async function hydrateEngrams(ids: string[]): Promise<SearchResult[]> {
+  if (!ids || ids.length === 0) return [];
+
+  const query = `
+    SELECT id, content, source_path, timestamp, buckets, tags, provenance, compound_id, start_byte, end_byte
+    FROM atoms
+    WHERE id = ANY($1)
+  `;
+
+  try {
+    const result = await db.run(query, [ids]);
+
+    return result.rows.map((row: any) => ({
+      id: row.id,
+      content: row.content,
+      source: row.source_path, // Map source_path to source
+      timestamp: row.timestamp,
+      buckets: row.buckets || [],
+      tags: row.tags || [],
+      epochs: '',
+      provenance: row.provenance || 'internal',
+      score: 1.0, // High score for direct engram hits
+      compound_id: row.compound_id,
+      start_byte: row.start_byte,
+      end_byte: row.end_byte
+    }));
+  } catch (e) {
+    console.error('[Search] Failed to hydrate engrams:', e);
+    return [];
+  }
+}
+
 import { PhysicsTagWalker } from './physics-tag-walker.js';
 import { assembleAndSerialize, assembleContextPackage } from './graph-context-serializer.js';
 import { UserContext } from '../../types/context.js';
@@ -115,7 +150,7 @@ export async function findAnchors(
     }
 
     let anchors: SearchResult[] = [];
-    let atomResults: SearchResult[] = [];
+    // let atomResults: SearchResult[] = []; // Removed duplicate declaration
 
     // A. Atom Search (Radial Inflation) - Use C++ results if available
     if (cppResults.length > 0) {
@@ -535,15 +570,11 @@ export async function executeSearch(
 
   // 2. Find Anchors (Planets)
   // Combine Engram Lookup + FTS + Molecule Search
-  const engramResults = await lookupByEngram(cleanQuery); // TODO: Hydrate these results
+  const engramIds = await lookupByEngram(cleanQuery);
+  const engramResults = await hydrateEngrams(engramIds);
   const primaryAnchors = await findAnchors(cleanQuery, Array.from(realBuckets), explicitTags, maxChars, provenance, filters);
 
-  // Clean up engram results if they are just IDs (lookupByEngram returns IDs? No, currently logic is missing hydration in my quick look, assuming compatible or empty)
-  // Actually lookupByEngram returns string[] of IDs. We need to fetch them.
-  // For now, let's rely on primaryAnchors.
-  // If we had time, we'd hydrate engrams.
-
-  const allAnchors = [...primaryAnchors];
+  const allAnchors = [...engramResults, ...primaryAnchors];
 
   // Deduplicate
   const seenIds = new Set<string>();


### PR DESCRIPTION
This PR hydrates the results from `lookupByEngram` in the search service. 
Previously, `lookupByEngram` returned only IDs, which were not being used correctly in the subsequent steps that expected `SearchResult` objects.
I added a `hydrateEngrams` helper function to fetch the full atom details from the database and updated `executeSearch` to include these hydrated engrams in the search results.
I also fixed a duplicate variable declaration (`atomResults`) in `findAnchors`.

---
*PR created automatically by Jules for task [13948705341081578732](https://jules.google.com/task/13948705341081578732) started by @RSBalchII*