### PR TITLE
feat(search): allow dynamic user context in search requests

### DIFF
--- a/engine/src/routes/api.ts
+++ b/engine/src/routes/api.ts
@@ -291,6 +291,7 @@ export function setupRoutes(app: Application) {
       const defaultLimit = 100000;
       const budget = (req.body as any).token_budget ? (req.body as any).token_budget * 4 : (body.max_chars || defaultLimit);
       const tags = (req.body as any).tags || [];
+      const userContext = body.user_context;
 
       // Enhanced Search Strategy (Standard 086)
       // Support both standard and max-recall strategies
@@ -305,7 +306,8 @@ export function setupRoutes(app: Application) {
           budget,
           tags,
           (req.body as any).provenance || 'all',
-          true  // useMaxRecall = true
+          true,  // useMaxRecall = true
+          userContext
         );
       } else {
         // Standard Strategy: Balanced 70/30 budget with temporal decay
@@ -315,7 +317,8 @@ export function setupRoutes(app: Application) {
           budget,
           tags,
           (req.body as any).provenance || 'all',
-          false  // useMaxRecall = false
+          false,  // useMaxRecall = false
+          userContext
         );
       }
 
@@ -433,6 +436,7 @@ export function setupRoutes(app: Application) {
       const allBuckets = bucketParam ? [...buckets, bucketParam] : buckets;
       const budget = body.token_budget ? body.token_budget * 4 : (body.max_chars || 2400); // Default to 2400 as specified
       const tags = body.tags || [];
+      const userContext = body.user_context;
 
       // Use Molecule Search Strategy - split query into sentence-like chunks
       const { executeMoleculeSearch } = await import('../services/search/search.js');
@@ -443,7 +447,8 @@ export function setupRoutes(app: Application) {
         budget,
         false, // deep
         'all', // provenance
-        tags
+        tags,
+        userContext
       );
 
       // Construct standard response
@@ -483,6 +488,7 @@ export function setupRoutes(app: Application) {
       // Default to 256K chars for max recall
       const budget = body.token_budget ? body.token_budget * 4 : (body.max_chars || 262144);
       const tags = body.tags || [];
+      const userContext = body.user_context;
 
       // Use max-recall configuration
       const { smartChatSearch } = await import('../services/search/search.js');
@@ -492,7 +498,8 @@ export function setupRoutes(app: Application) {
         budget,
         tags,
         'all', // provenance
-        true   // useMaxRecall = true
+        true,   // useMaxRecall = true
+        userContext
       );
 
       console.log(`[API] Max Recall Search "${body.query}" -> Found ${result.results.length} results`);

--- a/engine/src/routes/enhanced-api.ts
+++ b/engine/src/routes/enhanced-api.ts
@@ -24,7 +24,7 @@ export function setupEnhancedRoutes(app: Application) {
   // Enhanced search endpoint with Bright Node support
   app.post('/v1/memory/search-enhanced', async (req: Request, res: Response) => {
     try {
-      const { query, buckets, maxChars, provenance, includeGraph } = req.body;
+      const { query, buckets, maxChars, provenance, includeGraph, user_context } = req.body;
 
       // Default values
       const searchQuery = query || '';
@@ -40,7 +40,11 @@ export function setupEnhancedRoutes(app: Application) {
         searchBuckets,
         maxCharacters,
         false,
-        searchProvenance
+        searchProvenance,
+        [], // explicitTags
+        undefined, // filters
+        false, // useMaxRecall
+        user_context
       );
 
       // Optionally include Bright Node graph data

--- a/engine/src/services/search/search.ts
+++ b/engine/src/services/search/search.ts
@@ -115,7 +115,7 @@ export async function findAnchors(
     }
 
     let anchors: SearchResult[] = [];
-    let atomResults: SearchResult[] = [];
+    // let atomResults: SearchResult[] = []; // Removed duplicate declaration
 
     // A. Atom Search (Radial Inflation) - Use C++ results if available
     if (cppResults.length > 0) {
@@ -523,7 +523,8 @@ export async function executeSearch(
   provenance: 'internal' | 'external' | 'quarantine' | 'all' = 'all',
   explicitTags: string[] = [],
   filters?: { type?: string; minVal?: number; maxVal?: number; },
-  useMaxRecall: boolean = false
+  useMaxRecall: boolean = false,
+  userContext?: UserContext
 ): Promise<{ context: string; results: SearchResult[]; toAgentString: () => string; metadata?: any }> {
   console.log(`[Search] executeSearch (Physics Engine V2) called with provenance: ${provenance}`);
   const startTime = Date.now();
@@ -576,13 +577,13 @@ export async function executeSearch(
   }
 
   // 4. Graph-Context Serialization (GCP)
-  const userContext: UserContext = {
+  const finalUserContext: UserContext = userContext || {
     name: 'User', // TODO: Get from request context if available
     current_state: 'active'
   };
 
   const contextPackage = assembleContextPackage({
-    user: userContext,
+    user: finalUserContext,
     query: cleanQuery,
     keyTerms: cleanQuery.split(' '),
     scopeTags: explicitTags,
@@ -592,7 +593,7 @@ export async function executeSearch(
   });
 
   const serializedContext = assembleAndSerialize({
-    user: userContext,
+    user: finalUserContext,
     query: cleanQuery,
     keyTerms: cleanQuery.split(' '),
     scopeTags: explicitTags,
@@ -643,7 +644,8 @@ export async function executeMoleculeSearch(
   maxChars: number = config.SEARCH.max_chars_default, // Use config default (512KB)
   deep: boolean = false,
   provenance: 'internal' | 'external' | 'quarantine' | 'all' = 'all',
-  explicitTags: string[] = []
+  explicitTags: string[] = [],
+  userContext?: UserContext
 ): Promise<{ context: string; results: SearchResult[]; toAgentString: () => string; metadata?: any }> {
 
   // Split the query into molecules (sentence-like chunks)
@@ -666,7 +668,10 @@ export async function executeMoleculeSearch(
         maxChars,
         deep,
         provenance,
-        explicitTags
+        explicitTags,
+        undefined,
+        false,
+        userContext
       );
 
       // Add unique results to our collection
@@ -770,7 +775,8 @@ export async function iterativeSearch(
   maxChars: number = config.SEARCH.max_chars_default, // Use config default (512KB)
   tags: string[] = [],
   provenance: 'internal' | 'external' | 'quarantine' | 'all' = 'all',
-  useMaxRecall: boolean = false
+  useMaxRecall: boolean = false,
+  userContext?: UserContext
 ): Promise<{ context: string; results: SearchResult[]; attempt: number; metadata?: any; toAgentString: () => string }> {
 
   // 0. Extract Scope Tags (Hashtags) to preserve them across strategies
@@ -784,7 +790,7 @@ export async function iterativeSearch(
 
   // Strategy 1: Standard Expanded Search (All Nouns, Verbs, Dates + Expansion)
   console.log(`[IterativeSearch] Strategy 1: Standard Execution`);
-  let results = await executeSearch(query, undefined, buckets, maxChars, false, provenance, tags, undefined, useMaxRecall);
+  let results = await executeSearch(query, undefined, buckets, maxChars, false, provenance, tags, undefined, useMaxRecall, userContext);
   if (results.results.length > 0) return { ...results, attempt: 1 };
 
   // Strategy 2: Strict "Subjects & Time" (Strip Verbs/Adjectives, keep Nouns + Dates)
@@ -801,7 +807,7 @@ export async function iterativeSearch(
     // Re-inject scope tags
     const strictQuery = Array.from(uniqueTokens).join(' ') + ' ' + tagsString;
     console.log(`[IterativeSearch] Fallback Query 1: "${strictQuery.trim()}"`);
-    results = await executeSearch(strictQuery, undefined, buckets, maxChars, false, provenance, tags);
+    results = await executeSearch(strictQuery, undefined, buckets, maxChars, false, provenance, tags, undefined, undefined, userContext);
     if (results.results.length > 0) return { ...results, attempt: 2 };
   }
 
@@ -815,7 +821,7 @@ export async function iterativeSearch(
 
   if (entityQuery.trim().length > 0 && entityQuery.trim() !== (Array.from(uniqueTokens).join(' ') + ' ' + tagsString).trim()) {
     console.log(`[IterativeSearch] Fallback Query 2: "${entityQuery.trim()}"`);
-    results = await executeSearch(entityQuery, undefined, buckets, maxChars, false, provenance, tags);
+    results = await executeSearch(entityQuery, undefined, buckets, maxChars, false, provenance, tags, undefined, undefined, userContext);
     if (results.results.length > 0) return { ...results, attempt: 3 };
   }
 
@@ -839,7 +845,8 @@ export async function smartChatSearch(
   maxChars: number = 20000,
   tags: string[] = [],
   provenance: 'internal' | 'external' | 'quarantine' | 'all' = 'all',
-  useMaxRecall: boolean = false
+  useMaxRecall: boolean = false,
+  userContext?: UserContext
 ): Promise<{ context: string; results: SearchResult[]; strategy: string; splitQueries?: string[]; metadata?: any; toAgentString: () => string }> {
 
   const isLongQuery = query.length > 100;
@@ -847,7 +854,7 @@ export async function smartChatSearch(
 
   // 1. Initial Attempt (Skip if it's a massive max-recall query to force chunking)
   if (!isLongQuery || !useMaxRecall) {
-    initial = await iterativeSearch(query, buckets, maxChars, tags, provenance, useMaxRecall);
+    initial = await iterativeSearch(query, buckets, maxChars, tags, provenance, useMaxRecall, userContext);
 
     // If we have enough results, returns immediately
     if (initial.results.length >= 10 && !useMaxRecall) {
@@ -903,7 +910,7 @@ export async function smartChatSearch(
   // For max-recall mode, give each sub-query the full budget to maximize retrieval
   const budgetPerQuery = useMaxRecall ? maxChars : Math.floor(maxChars / splitQueries.length);
   const parallelPromises = splitQueries.map((entity: string) =>
-    executeSearch(entity, undefined, buckets, budgetPerQuery, false, provenance, tags, undefined, useMaxRecall)
+    executeSearch(entity, undefined, buckets, budgetPerQuery, false, provenance, tags, undefined, useMaxRecall, userContext)
   );
 
   const parallelResults = await Promise.all(parallelPromises);
@@ -950,13 +957,13 @@ export async function smartChatSearch(
   }
 
   // 5. Re-Format using GCP (Standard 086)
-  const userContext: UserContext = {
+  const finalUserContext: UserContext = userContext || {
     name: 'User',
     current_state: 'active'
   };
 
   const serializedContext = assembleAndSerialize({
-    user: userContext,
+    user: finalUserContext,
     query: query,
     keyTerms: splitQueries,
     scopeTags: tags,

--- a/engine/src/types/api.ts
+++ b/engine/src/types/api.ts
@@ -1,4 +1,6 @@
 
+import { UserContext } from './context.js';
+
 export interface Menu {
     id: string;
     content: string;
@@ -21,6 +23,8 @@ export interface SearchRequest {
     // The "UniversalRAG" Routing Layer
     buckets?: string[];      // e.g., ["@code", "@visual", "@memory"]
     provenance?: 'internal' | 'external' | 'quarantine' | 'all'; // Data Provenance filter
+
+    user_context?: UserContext; // Federated Sovereignty (User Context)
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
🎯 **What:**
Replaced the hardcoded `UserContext` in `engine/src/services/search/search.ts` with a dynamic mechanism. Added `user_context` field to `SearchRequest` and propagated it through the search service stack (`executeSearch`, `iterativeSearch`, `smartChatSearch`, etc.) and API routes.

💡 **Why:**
The previous implementation hardcoded the user context to `{ name: 'User', current_state: 'active' }`, limiting the engine's ability to adapt results based on who is asking (Federated Sovereignty). This change allows the API caller to provide the user's identity and state, which is critical for personalized graph traversal and context assembly.

✅ **Verification:**
- Verified using a custom test script `engine/tests/unit/verify_user_context.ts` (created and then deleted) which mocked the DB and called `executeSearch` with a custom user context, confirming that the output context string contained the custom user name.
- Verified that default behavior (when no user context is provided) remains unchanged (defaults to 'User').
- Fixed a pre-existing duplicate variable declaration in `search.ts` that was discovered during verification.

✨ **Result:**
The search engine now supports dynamic user context, improving the flexibility and correctness of the Graph-Context Protocol (GCP).

---
*PR created automatically by Jules for task [5262940268487813434](https://jules.google.com/task/5262940268487813434) started by @RSBalchII*