### PR TITLE
Implement tag-based neighbor finding

### DIFF
--- a/cpp/src/graph_traversal.cpp
+++ b/cpp/src/graph_traversal.cpp
@@ -34,8 +34,24 @@ std::vector<Edge> bfsTraversal(Database& db, AtomId start_id, int max_hops) {
 }
 
 std::vector<AtomId> findTagNeighbors(Database& db, AtomId atom_id) {
-    // TODO: Implement tag-based neighbor finding
-    return {};
+    std::unordered_set<AtomId> neighbor_ids;
+
+    // Get all tags for the source atom
+    std::vector<Tag> source_tags = db.getTagsForAtom(atom_id);
+
+    // For each tag, find all atoms sharing that tag
+    for (const auto& tag : source_tags) {
+        std::vector<Atom> atoms_with_tag = db.getAtomsByTag(tag.tag);
+        for (const auto& atom : atoms_with_tag) {
+            // Add to neighbors if it's not the original atom
+            if (atom.id != atom_id) {
+                neighbor_ids.insert(atom.id);
+            }
+        }
+    }
+
+    // Convert set back to vector
+    return std::vector<AtomId>(neighbor_ids.begin(), neighbor_ids.end());
 }
 
 } // namespace anchor

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -3,3 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 add_executable(test_atom_metadata test_atom_metadata.cpp)
 target_link_libraries(test_atom_metadata PRIVATE anchor_core)
 add_test(NAME test_atom_metadata COMMAND test_atom_metadata)
+
+add_executable(test_graph_traversal test_graph_traversal.cpp)
+target_link_libraries(test_graph_traversal PRIVATE anchor_core)
+add_test(NAME test_graph_traversal COMMAND test_graph_traversal)

--- a/cpp/tests/test_graph_traversal.cpp
+++ b/cpp/tests/test_graph_traversal.cpp
@@ -104,16 +104,129 @@ void test_bfs() {
     }
 
     assert(result_edges.size() == 3);
-    assert(found_1_2);
-    assert(found_1_3);
-    assert(found_2_4);
+    (void)found_1_2; assert(found_1_2);
+    (void)found_1_3; assert(found_1_3);
+    (void)found_2_4; assert(found_2_4);
 
     std::cout << "BFS Traversal Test Passed!" << std::endl;
+}
+
+void test_findTagNeighbors() {
+    std::cout << "Testing findTagNeighbors..." << std::endl;
+
+    // Create in-memory database
+    Database db = Database::inMemory();
+
+    // Insert sources first
+    Source s1;
+    s1.id = "src1";
+    s1.path = "path/to/src1";
+    s1.created_at = 100.0;
+    s1.updated_at = 100.0;
+    db.upsertSource(s1);
+
+    // Insert atoms
+    Atom a1;
+    a1.source_id = "src1";
+    a1.content = "content1";
+    AtomId id1 = db.insertAtom(a1);
+
+    Atom a2;
+    a2.source_id = "src1";
+    a2.content = "content2";
+    AtomId id2 = db.insertAtom(a2);
+
+    Atom a3;
+    a3.source_id = "src1";
+    a3.content = "content3";
+    AtomId id3 = db.insertAtom(a3);
+
+    Atom a4;
+    a4.source_id = "src1";
+    a4.content = "content4";
+    AtomId id4 = db.insertAtom(a4);
+
+    // Add tags
+    // a1 has tags "A", "B"
+    db.addTags(id1, {
+        {0, id1, "A", std::nullopt},
+        {0, id1, "B", std::nullopt}
+    });
+
+    // a2 has tags "B", "C"
+    db.addTags(id2, {
+        {0, id2, "B", std::nullopt},
+        {0, id2, "C", std::nullopt}
+    });
+
+    // a3 has tag "A"
+    db.addTags(id3, {
+        {0, id3, "A", std::nullopt}
+    });
+
+    // a4 has tag "D" (no overlap)
+    db.addTags(id4, {
+        {0, id4, "D", std::nullopt}
+    });
+
+    // Test a1 neighbors
+    // Should return id2 (shares "B") and id3 (shares "A")
+    std::vector<AtomId> a1_neighbors = findTagNeighbors(db, id1);
+    assert(a1_neighbors.size() == 2);
+
+    bool found_id2 = false;
+    bool found_id3 = false;
+    for (AtomId neighbor_id : a1_neighbors) {
+        if (neighbor_id == id2) found_id2 = true;
+        if (neighbor_id == id3) found_id3 = true;
+        // Verify we don't return the source atom itself
+        assert(neighbor_id != id1);
+    }
+    (void)found_id2; assert(found_id2);
+    (void)found_id3; assert(found_id3);
+
+    // Test a2 neighbors
+    // Should return id1 (shares "B")
+    std::vector<AtomId> a2_neighbors = findTagNeighbors(db, id2);
+    assert(a2_neighbors.size() == 1);
+    assert(a2_neighbors[0] == id1);
+
+    // Test a3 neighbors
+    // Should return id1 (shares "A")
+    std::vector<AtomId> a3_neighbors = findTagNeighbors(db, id3);
+    assert(a3_neighbors.size() == 1);
+    assert(a3_neighbors[0] == id1);
+
+    // Test a4 neighbors
+    // Should return empty (no shared tags)
+    std::vector<AtomId> a4_neighbors = findTagNeighbors(db, id4);
+    assert(a4_neighbors.empty());
+
+    // Test deduplication
+    // Let's add tag "A" to a2 as well, so a1 and a2 now share "A" and "B"
+    db.addTags(id2, {
+        {0, id2, "A", std::nullopt}
+    });
+
+    a1_neighbors = findTagNeighbors(db, id1);
+    assert(a1_neighbors.size() == 2); // Still just id2 and id3, deduplicated correctly
+
+    found_id2 = false;
+    found_id3 = false;
+    for (AtomId neighbor_id : a1_neighbors) {
+        if (neighbor_id == id2) found_id2 = true;
+        if (neighbor_id == id3) found_id3 = true;
+    }
+    (void)found_id2; assert(found_id2);
+    (void)found_id3; assert(found_id3);
+
+    std::cout << "findTagNeighbors Test Passed!" << std::endl;
 }
 
 int main() {
     try {
         test_bfs();
+        test_findTagNeighbors();
     } catch (const std::exception& e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;
         return 1;


### PR DESCRIPTION
Implemented the `findTagNeighbors` function which uses existing `Database` methods to find all neighbor atoms sharing at least one tag with a given source atom. It successfully deduplicates the results and omits the source atom itself. Added robust test cases to `test_graph_traversal.cpp` to verify this behavior, and registered the test in `CMakeLists.txt`. Fixed a minor compiler warning in existing asserts in `test_graph_traversal.cpp` that appeared in Release builds.

---
*PR created automatically by Jules for task [15716095286817069592](https://jules.google.com/task/15716095286817069592) started by @RSBalchII*