### PR TITLE
🧪 [Testing Improvement] Add unit test for exported nativeModuleManager singleton

### DIFF
--- a/engine/tests/unit/native-module-manager.test.ts
+++ b/engine/tests/unit/native-module-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NativeModuleManager } from '../../src/utils/native-module-manager.js';
+import { NativeModuleManager, nativeModuleManager } from '../../src/utils/native-module-manager.js';
 import { pathManager } from '../../src/utils/path-manager.js';
 
 // Mock pathManager
@@ -48,6 +48,18 @@ describe('NativeModuleManager', () => {
       const instance1 = NativeModuleManager.getInstance();
       const instance2 = NativeModuleManager.getInstance();
       expect(instance1).toBe(instance2);
+    });
+
+    it('should export a singleton instance', () => {
+      expect(nativeModuleManager).toBeDefined();
+      expect(nativeModuleManager).toBeInstanceOf(NativeModuleManager);
+      // Since beforeEach resets the instance, the exported one might be different from the one created in beforeEach if it was imported earlier
+      // The exported instance is created once when the module is evaluated.
+      // So we test that it has the expected methods of a NativeModuleManager instance
+      expect(nativeModuleManager.loadNativeModule).toBeInstanceOf(Function);
+      expect(nativeModuleManager.getStatus).toBeInstanceOf(Function);
+      expect(nativeModuleManager.isUsingFallback).toBeInstanceOf(Function);
+      expect(nativeModuleManager.getAllStatus).toBeInstanceOf(Function);
     });
   });
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The exported `nativeModuleManager` singleton instance in `engine/src/utils/native-module-manager.ts` was not directly tested in the corresponding unit test file.

📊 **Coverage:** What scenarios are now tested
Added a test verifying that the exported constant `nativeModuleManager` exists, is an instance of `NativeModuleManager`, and exposes the expected class methods (e.g. `loadNativeModule`, `getStatus`).

✨ **Result:** The improvement in test coverage
Ensures that the actual exported module value matches the expected singleton behavior and API surface, preventing regression issues where the module export might accidentally be altered.

---
*PR created automatically by Jules for task [10630714499199214358](https://jules.google.com/task/10630714499199214358) started by @RSBalchII*