### PR TITLE
🧪 testing improvement: add safe-dns coverage and fix ssrf bypass

### DIFF
--- a/engine/src/utils/safe-dns.ts
+++ b/engine/src/utils/safe-dns.ts
@@ -8,12 +8,29 @@ import dns from 'node:dns';
  * @returns true if the IP is private or reserved, false otherwise.
  */
 export function isPrivateIP(ip: string): boolean {
+    // IPv6 with embedded IPv4 (e.g., ::ffff:127.0.0.1)
+    if (ip.includes(':') && ip.includes('.')) {
+        const lowerIp = ip.toLowerCase();
+
+        // IPv4-mapped IPv6 ::ffff:127.0.0.1
+        if (lowerIp.startsWith('::ffff:')) {
+            const ipv4 = lowerIp.substring(7);
+             if (ipv4.includes('.')) {
+                 return isPrivateIP(ipv4);
+             }
+        }
+
+        // Also check for 0:0:0:0:0:ffff:127.0.0.1 style if not normalized
+        // It's likely an embedded IPv4
+        const parts = lowerIp.split(':');
+        const lastPart = parts[parts.length - 1];
+        if (lastPart.includes('.')) {
+            return isPrivateIP(lastPart);
+        }
+    }
+
     // IPv4
     if (ip.includes('.')) {
-        // If it also contains ':', it might be IPv6 mapped, but usually IPv4 doesn't contain ':'.
-        // However, if it's strictly IPv4, it shouldn't have ':'.
-        // If it's IPv6 with embedded IPv4, it falls into the else if below unless it's just an IPv4 string.
-
         const parts = ip.split('.').map(Number);
         if (parts.length !== 4) return false;
 
@@ -53,24 +70,6 @@ export function isPrivateIP(ip: string): boolean {
 
         // fe80::/10 - Link-local
         if (lowerIp.startsWith('fe8') || lowerIp.startsWith('fe9') || lowerIp.startsWith('fea') || lowerIp.startsWith('feb')) return true;
-
-        // IPv4-mapped IPv6 ::ffff:127.0.0.1
-        if (lowerIp.startsWith('::ffff:')) {
-            const ipv4 = lowerIp.substring(7);
-             if (ipv4.includes('.')) {
-                 return isPrivateIP(ipv4);
-             }
-        }
-
-        // Also check for 0:0:0:0:0:ffff:127.0.0.1 style if not normalized
-        if (lowerIp.includes('.')) {
-             // It's likely an embedded IPv4
-             const parts = lowerIp.split(':');
-             const lastPart = parts[parts.length - 1];
-             if (lastPart.includes('.')) {
-                 return isPrivateIP(lastPart);
-             }
-        }
 
         return false;
     }

--- a/engine/tests/unit/safe-dns.test.ts
+++ b/engine/tests/unit/safe-dns.test.ts
@@ -1,0 +1,182 @@
+import { jest } from '@jest/globals';
+import dns from 'node:dns';
+import { isPrivateIP, safeLookup } from '../../src/utils/safe-dns.js';
+
+describe('safe-dns', () => {
+    describe('isPrivateIP', () => {
+        it('should return true for private IPv4 addresses', () => {
+            // Loopback
+            expect(isPrivateIP('127.0.0.1')).toBe(true);
+            expect(isPrivateIP('127.255.255.255')).toBe(true);
+
+            // Private Networks
+            expect(isPrivateIP('10.0.0.1')).toBe(true);
+            expect(isPrivateIP('10.255.255.255')).toBe(true);
+            expect(isPrivateIP('192.168.0.1')).toBe(true);
+            expect(isPrivateIP('192.168.255.255')).toBe(true);
+            expect(isPrivateIP('172.16.0.1')).toBe(true);
+            expect(isPrivateIP('172.31.255.255')).toBe(true);
+
+            // Link-local
+            expect(isPrivateIP('169.254.0.1')).toBe(true);
+            expect(isPrivateIP('169.254.255.255')).toBe(true);
+
+            // Current network
+            expect(isPrivateIP('0.0.0.0')).toBe(true);
+        });
+
+        it('should return false for public IPv4 addresses', () => {
+            expect(isPrivateIP('8.8.8.8')).toBe(false);
+            expect(isPrivateIP('1.1.1.1')).toBe(false);
+            expect(isPrivateIP('172.15.255.255')).toBe(false); // Just outside 172.16.x.x
+            expect(isPrivateIP('172.32.0.0')).toBe(false); // Just outside 172.31.x.x
+            expect(isPrivateIP('192.169.0.1')).toBe(false);
+            expect(isPrivateIP('11.0.0.1')).toBe(false);
+        });
+
+        it('should return false for invalid IPv4 formats', () => {
+            expect(isPrivateIP('127.1')).toBe(false);
+            expect(isPrivateIP('127.0.0')).toBe(false);
+            expect(isPrivateIP('not.an.ip.address')).toBe(false);
+            expect(isPrivateIP('')).toBe(false);
+        });
+
+        it('should return true for private IPv6 addresses', () => {
+            // Loopback
+            expect(isPrivateIP('::1')).toBe(true);
+            expect(isPrivateIP('0:0:0:0:0:0:0:1')).toBe(true);
+
+            // Unspecified
+            expect(isPrivateIP('::')).toBe(true);
+            expect(isPrivateIP('0:0:0:0:0:0:0:0')).toBe(true);
+
+            // Unique Local Address
+            expect(isPrivateIP('fc00::1')).toBe(true);
+            expect(isPrivateIP('fd00::1')).toBe(true);
+            expect(isPrivateIP('fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(true);
+
+            // Link-local
+            expect(isPrivateIP('fe80::1')).toBe(true);
+            expect(isPrivateIP('fe90::1')).toBe(true);
+            expect(isPrivateIP('fea0::1')).toBe(true);
+            expect(isPrivateIP('feb0::1')).toBe(true);
+
+            // IPv4-mapped IPv6
+            expect(isPrivateIP('::ffff:127.0.0.1')).toBe(true);
+            expect(isPrivateIP('0:0:0:0:0:ffff:10.0.0.1')).toBe(true);
+        });
+
+        it('should return false for public IPv6 addresses', () => {
+            expect(isPrivateIP('2001:4860:4860::8888')).toBe(false); // Google DNS
+            expect(isPrivateIP('2606:4700:4700::1111')).toBe(false); // Cloudflare DNS
+            expect(isPrivateIP('::ffff:8.8.8.8')).toBe(false); // IPv4-mapped public IP
+        });
+
+        it('should return false for invalid strings that are not IPs', () => {
+             expect(isPrivateIP('hello-world')).toBe(false);
+        });
+    });
+
+    describe('safeLookup', () => {
+        let lookupSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            // Spy on dns.lookup and mock its implementation
+            lookupSpy = jest.spyOn(dns, 'lookup');
+        });
+
+        afterEach(() => {
+            // Restore original implementation
+            lookupSpy.mockRestore();
+        });
+
+        it('should call callback with public IP address (string)', (done) => {
+            lookupSpy.mockImplementation((hostname, options, callback) => {
+                // Mock callback for dns.lookup without options usually returns (err, address, family)
+                if (typeof options === 'function') {
+                    options(null, '8.8.8.8', 4);
+                } else {
+                    (callback as Function)(null, '8.8.8.8', 4);
+                }
+            });
+
+            safeLookup('public.example.com', { all: false }, (err, address, family) => {
+                expect(err).toBeNull();
+                expect(address).toBe('8.8.8.8');
+                expect(family).toBe(4);
+                done();
+            });
+        });
+
+        it('should return an error for private IP address (string)', (done) => {
+            lookupSpy.mockImplementation((hostname, options, callback) => {
+                if (typeof options === 'function') {
+                    options(null, '127.0.0.1', 4);
+                } else {
+                    (callback as Function)(null, '127.0.0.1', 4);
+                }
+            });
+
+            safeLookup('private.example.com', { all: false }, (err, address, family) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err?.message).toMatch(/resolved to a private IP/);
+                expect((err as any)?.code).toBe('ERR_SSRF_PROTECTION');
+                done();
+            });
+        });
+
+        it('should call callback with public IP addresses (array)', (done) => {
+            const mockAddresses = [{ address: '8.8.8.8', family: 4 }, { address: '1.1.1.1', family: 4 }];
+            lookupSpy.mockImplementation((hostname, options, callback) => {
+                if (typeof options === 'function') {
+                    options(null, mockAddresses as any);
+                } else {
+                    (callback as Function)(null, mockAddresses);
+                }
+            });
+
+            safeLookup('public.example.com', { all: true }, (err, address) => {
+                expect(err).toBeNull();
+                expect(address).toEqual(mockAddresses);
+                done();
+            });
+        });
+
+        it('should return an error if any IP in array is private', (done) => {
+            const mockAddresses = [{ address: '8.8.8.8', family: 4 }, { address: '10.0.0.1', family: 4 }];
+            lookupSpy.mockImplementation((hostname, options, callback) => {
+                if (typeof options === 'function') {
+                    options(null, mockAddresses as any);
+                } else {
+                    (callback as Function)(null, mockAddresses);
+                }
+            });
+
+            safeLookup('mixed.example.com', { all: true }, (err, address) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err?.message).toMatch(/resolved to a private IP/);
+                expect((err as any)?.code).toBe('ERR_SSRF_PROTECTION');
+                done();
+            });
+        });
+
+        it('should pass through DNS lookup errors', (done) => {
+            const mockError = new Error('getaddrinfo ENOTFOUND invalid.example.com');
+            (mockError as any).code = 'ENOTFOUND';
+
+            lookupSpy.mockImplementation((hostname, options, callback) => {
+                if (typeof options === 'function') {
+                    options(mockError, undefined);
+                } else {
+                    (callback as Function)(mockError, undefined);
+                }
+            });
+
+            safeLookup('invalid.example.com', { all: false }, (err, address) => {
+                expect(err).toBe(mockError);
+                expect((err as any)?.code).toBe('ENOTFOUND');
+                done();
+            });
+        });
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      tar:
+        specifier: ^7.5.10
+        version: 7.5.10
       turndown:
         specifier: ^7.2.2
         version: 7.2.2


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `isPrivateIP` and `safeLookup` functions in `engine/src/utils/safe-dns.ts` were lacking test coverage, leaving the SSRF protection mechanism vulnerable to regression.

📊 **Coverage:** What scenarios are now tested
- Validates standard private IPv4 and IPv6 addresses.
- Verifies public IPv4 and IPv6 addresses are permitted.
- Ensures invalid IP strings and incorrectly formatted IPs are handled safely.
- Mocks DNS lookups to verify `safeLookup` properly prevents resolving to private IPs for both string and array returns.

✨ **Result:** The improvement in test coverage
Tests passing with full coverage for `safe-dns`. A minor security bypass was also identified and patched where IPv4-mapped IPv6 IPs were incorrectly evaluated.

---
*PR created automatically by Jules for task [6743350395060984015](https://jules.google.com/task/6743350395060984015) started by @RSBalchII*