### PR TITLE
🔒 fix(system): patch command injection in system explorer route

### DIFF
--- a/engine/src/routes/v1/system.ts
+++ b/engine/src/routes/v1/system.ts
@@ -160,16 +160,18 @@ export function setupSystemRoutes(app: Application) {
         return;
       }
 
-      const { exec } = await import('child_process');
+      const { execFile } = await import('child_process');
+      const util = await import('util');
+      const execFilePromise = util.promisify(execFile);
       const platform = process.platform;
 
-      // Open file explorer based on platform
+      // Open file explorer based on platform safely using execFile
       if (platform === 'win32') {
-        exec(`explorer.exe "${path}"`);
+        await execFilePromise('explorer.exe', [path]);
       } else if (platform === 'darwin') {
-        exec(`open "${path}"`);
+        await execFilePromise('open', [path]);
       } else {
-        exec(`xdg-open "${path}"`);
+        await execFilePromise('xdg-open', [path]);
       }
 
       res.status(200).json({


### PR DESCRIPTION
🎯 **What:** The `POST /v1/system/explorer` route was vulnerable to command injection because it interpolated user-provided input (`path`) directly into a shell command using `child_process.exec()`.

⚠️ **Risk:** An attacker could craft a malicious path payload that allows them to execute arbitrary shell commands on the host machine running the Anchor Engine backend. This could result in a full compromise of the application or the server, exposing all indexed data and potentially leading to further exploitation within the internal network.

🛡️ **Solution:** The fix replaces `child_process.exec()` with a promisified version of `child_process.execFile()`. Instead of concatenating the user's path into a shell string, the path is now passed securely as an argument array. This ensures that the underlying operating system treats the input strictly as data (an argument) and never evaluates it as an executable command or shell directive. Furthermore, the execution is properly `await`ed within the route's `try/catch` block, ensuring any process execution errors return a 500 response.

---
*PR created automatically by Jules for task [1780386743145102251](https://jules.google.com/task/1780386743145102251) started by @RSBalchII*